### PR TITLE
Change PR trigger phrase to use ThreadString

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.42.4-SNAPSHOT</version>
+    <version>1.42.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://github.com/jenkinsci/ghprb-plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/RegexUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/RegexUtil.java
@@ -20,7 +20,7 @@ final class RegexUtil {
 
     public static boolean find(Pattern pattern, String input, int timeoutMillis) {
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<Boolean> future = executor.submit(() -> pattern.matcher(input).find());
+        Future<Boolean> future = executor.submit(() -> pattern.matcher(new ThreadString(input)).matches());
         try {
             return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/ThreadString.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/ThreadString.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.ghprb;
+
+/**
+ * A representation of text that can check its container thread for interruptions.
+ * This allows a break within tight charAt(..) calling loops, which can otherwise become infinite in a corrupt find.
+ */
+final class ThreadString implements CharSequence {
+    private final CharSequence delegate;
+
+    ThreadString(final CharSequence input) {
+        delegate = input;
+    }
+
+    @Override
+    public char charAt(final int index) {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException(new InterruptedException());
+        }
+        return delegate.charAt(index);
+    }
+
+    @Override
+    public int length() {
+        return delegate.length();
+    }
+
+    @Override
+    public CharSequence subSequence(final int start, final int end) {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException(new InterruptedException());
+        }
+        return new ThreadString(delegate.subSequence(start, end));
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ghprb/RegexUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/RegexUtilTest.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.ghprb;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class RegexUtilTest {
+
+    @Test
+    public void testRegexForTimeout() {
+        Pattern pattern = Pattern.compile("(a+)+b");
+        String input = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaac";
+        boolean result = RegexUtil.find(pattern, input, 1000);
+        assertThat(result).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
In Java, the `java.lang.String` class is not thread interrupt aware. If it is matched against a regex that is causing infinite backtracking even if the thread in which it running is interrupted it will continue the match forever. To avoid such behaviour ThreadString implementation is introduced in this PR.